### PR TITLE
Fix syntax errors with MUI label style overrides

### DIFF
--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -39,12 +39,14 @@ const theme = createTheme({
             }
         },MuiStepLabel: {
 			styleOverrides: {
-				active: {
-					color: "#4285F4",
-				},
-				completed: {
-					color: "white",
-				},
+                root: {
+                    "&.Mui-active": {
+                        color: "#4285F4",
+                    },
+                    "&.Mui-completed": {
+                        color: "white",
+                    },
+                }
 			},
 		},
 		MuiStepIcon: {


### PR DESCRIPTION
MUI disallows directly accessing CSS classes, instead, they must be indirectly accessed using the variant with the. Mui- prefix.

Available classes: <https://mui.com/material-ui/api/step-label/#classes>
