### PR TITLE
setup codegen with dev script in frontend; added examples for usage of typed queries

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # production
-/build
+/dist
 
 # misc
 .DS_Store

--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -6,9 +6,12 @@ import type { CodegenConfig } from "@graphql-codegen/cli";
  */
 const config: CodegenConfig = {
 	schema: "http://localhost:8080/",
-	documents: ["./src/**/*.ts", "./src/**/*.tsx", "!./src/repositories/**/**"],
-	ignoreNoDocuments: true,
+	documents: [
+		"./src/apiInterface/example/gqlStringsExample.ts",
+		"./src/apiInterface/gqlOperations.ts",
+	],
 
+	ignoreNoDocuments: true,
 	generates: {
 		"./src/__generated__/": {
 			preset: "client",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -67,6 +67,7 @@
         "@types/react": "^18.2.64",
         "@types/react-input-mask": "^3.0.5",
         "@types/styled-components": "^5.1.34",
+        "concurrently": "^9.0.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.34.2",
@@ -6208,6 +6209,116 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/concurrently": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.0.1.tgz",
+      "integrity": "sha512-wYKvCd/f54sTXJMSfV6Ln/B8UrfLBKOYa+lzc6CHay3Qek+LorVSBdMVfyewFhRbH0Rbabsk4D+3PL/VjQ5gzg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concurrently/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -12143,6 +12254,15 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,7 @@
     "web-vitals": "^4.2.2"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently --raw \"npm run codegen:dev\" \"vite\"",
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview",
@@ -63,8 +63,8 @@
     "lint-fix": "run-script-os",
     "lint-fix:windows": "eslint --fix .& prettier . --write",
     "lint-fix:nix": "eslint --fix .; prettier . --write",
-    "codegen": "graphql-codegen --config codegen.ts --watch",
-    "codegen:start": "graphql-codegen --config codegen.ts"
+    "codegen": "graphql-codegen --config codegen.ts --verbose",
+    "codegen:dev": "graphql-codegen --config codegen.ts --watch"
   },
   "eslintConfig": {
     "extends": [
@@ -96,6 +96,7 @@
     "@types/react": "^18.2.64",
     "@types/react-input-mask": "^3.0.5",
     "@types/styled-components": "^5.1.34",
+    "concurrently": "^9.0.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.34.2",

--- a/frontend/src/apiInterface/example/gqlStringsExample.ts
+++ b/frontend/src/apiInterface/example/gqlStringsExample.ts
@@ -1,0 +1,39 @@
+import { graphql } from "@/__generated__";
+/*
+ * This file contains all the GraphQL queries and mutations used in the application.
+ * This file is used by the GraphQL Code Generator to generate TypeScript types.
+ */
+
+/*
+ * NOTE: If the generated type is unknown and no error is being thrown,
+ * it is likely that the there is an error in a recent change you made. Try removing your changes
+ * and see if the error persists. If it does not, then the error is likely in your changes.
+ *
+ * Otherwise, the schema may have changed and codegen is not throwing an error,
+ * look for the recent changes in the schema manually and update the queries accordingly.
+ *
+ * Alternatively, remove a Query/Mutation one by one and rerun codegen
+ * to find the operation that is causing the error.
+ */
+export const Queries = {
+	GET_URL_AND_USERS: graphql(`
+		query GetURLAndUser {
+			generatePresignedURL
+			getUsers {
+				_id
+			}
+		}
+	`),
+};
+
+export const Mutations = {
+	DELETE_USER: graphql(`
+		mutation CreateUser($userInput: UserInput!) {
+			createUser(userInput: $userInput) {
+				code
+				id
+				response
+			}
+		}
+	`),
+};

--- a/frontend/src/apiInterface/example/usageInComponents.ts
+++ b/frontend/src/apiInterface/example/usageInComponents.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import graphQLClient from "../client";
+import { Queries } from "./gqlStringsExample";
+
+/*
+ * This is an example of how to use the generated code in a component using useQuery.
+ * Please read more about the useQuery hook in the react-query documentation.
+ */
+const { data } = useQuery({
+	queryKey: ["GetURLAndUsers"],
+	queryFn: async () => await graphQLClient.request(Queries.GET_URL_AND_USERS),
+});
+// data is fully typed
+data?.generatePresignedURL;
+data?.getUsers;
+
+/* Alternatively,
+ * This is an example of how to use the generated code in a component using a regular function.
+ * It can be used inside a useEffect hook or in a regular function.
+ */
+(async () => {
+	graphQLClient.request(Queries.GET_URL_AND_USERS).then((data) => {
+		// data is fully typed
+		console.log(data.generatePresignedURL);
+		console.log(data.getUsers);
+	});
+})();

--- a/frontend/src/apiInterface/gqlOperations.ts
+++ b/frontend/src/apiInterface/gqlOperations.ts
@@ -1,17 +1,21 @@
-import { gql } from "graphql-request";
+import { graphql } from "@/__generated__";
 
-export const topicsQuery = gql`
+/*
+ * To read more, go to ./example/gqlStringsExample.ts
+ */
+
+export const topicsQuery = graphql(`
 	query GetTopics {
 		options: getTopics {
 			name
 		}
 	}
-`;
+`);
 
-export const motivesQuery = gql`
+export const motivesQuery = graphql(`
 	query GetMotives {
 		options: getMotives {
 			name
 		}
 	}
-`;
+`);


### PR DESCRIPTION
Changes:
The change in frontend/.gitignore was made as vite uses dist folder instead of build folder for build files. 
Other changes are related to making codegen work with dev script and adding examples.