### PR TITLE
frontend deployment fix

### DIFF
--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -5,7 +5,7 @@ import type { CodegenConfig } from "@graphql-codegen/cli";
  * generate TypeScript types from the GraphQL schema and operations.
  */
 const config: CodegenConfig = {
-	schema: "http://localhost:8080/",
+	schema: "../backend/src/graphql/typedefs.ts",
 	documents: [
 		"./src/apiInterface/example/gqlStringsExample.ts",
 		"./src/apiInterface/gqlOperations.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "dev": "concurrently --raw \"npm run codegen:dev\" \"vite\"",
     "start": "vite",
-    "build": "vite build",
+    "build": "npm run codegen && vite build",
     "preview": "vite preview",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
The frontend deployement errors is due to graphql codegen not exisiting when importing, the build command has been updated to include codegen